### PR TITLE
Add night-image opacity to atmosphere layer

### DIFF
--- a/examples/NightSkyAnimation.html
+++ b/examples/NightSkyAnimation.html
@@ -6,7 +6,9 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
+		<link rel="stylesheet" href="//ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/themes/smoothness/jquery-ui.min.css">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js" type="text/javascript"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js" type="text/javascript"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
     <script data-main="NightSkyAnimation" src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.17/require.min.js"></script>
 </head>
@@ -23,6 +25,10 @@
             <br>
             <h4>Layers</h4>
             <div class="list-group" id="layerList">
+            </div>
+						<div>
+                <h5>Night Opacity<span id="opacity" class="pull-right"></span></h5>
+                <div id="opacitySlider"></div>                            
             </div>
             <br>
             <h4>Destination</h4>

--- a/examples/NightSkyAnimation.js
+++ b/examples/NightSkyAnimation.js
@@ -82,4 +82,24 @@ requirejs([
 
         // Create a layer manager for controlling layer visibility.
         var layerManager = new LayerManager(wwd);
+        
+        // Set the initial opacity of the night image to be slightly transparent
+        atmosphereLayer.opacity = 0.7;
+        
+        // Add a slider to control the night image opacity
+        $( document ).ready( function() {
+            var opacitySlider = $("#opacitySlider");
+            opacitySlider.slider({
+                value: 0.7,
+                min: 0,
+                max: 1,
+                step: 0.1,
+                animate: true,
+                slide: function (event, ui) {
+                    $("#opacity").html(ui.value);
+                    atmosphereLayer.opacity = ui.value;
+                }
+            });
+            opacitySlider.slider('value', atmosphereLayer.opacity);        
+        });
     });

--- a/src/layer/AtmosphereLayer.js
+++ b/src/layer/AtmosphereLayer.js
@@ -220,6 +220,8 @@ define([
 
             program.loadLightDirection(gl, this._activeLightDirection);
 
+            program.loadOpacity(gl, this.opacity);
+            
             program.setScale(gl);
 
             // Use this layer's night image when the layer has time value defined

--- a/src/shaders/AtmosphereProgram.js
+++ b/src/shaders/AtmosphereProgram.js
@@ -151,6 +151,13 @@ define([
              * @readonly
              */
             this.scaleLocation = this.uniformLocation(gl, "scale");
+            
+            /**
+             * The WebGL location for this program's 'opacity' uniform.
+             * @type {WebGLUniformLocation}
+             * @readonly
+             */
+            this.opacityLocation = this.uniformLocation(gl, "opacity");
 
             /**
              * The WebGL location for this program's 'scaleDepth' uniform.
@@ -320,6 +327,20 @@ define([
 
             matrix.columnMajorComponents(this.scratchArray9);
             gl.uniformMatrix3fv(this.texCoordMatrixLocation, false, this.scratchArray9);
+        };
+
+        /**
+         * Loads the specified opacity as the value of this program's 'opacity' uniform variable.
+         * @param {WebGLRenderingContext} gl The current WebGL context.
+         * @param {Number} opacity The opacity value.
+         */
+        AtmosphereProgram.prototype.loadOpacity = function (gl, opacity) {
+            if (opacity === undefined) {
+                throw new ArgumentError(
+                    Logger.logMessage(Logger.LEVEL_SEVERE, "AtmosphereProgram", "loadOpacity",
+                        "missingOpacity"));
+            }
+            gl.uniform1f(this.opacityLocation, opacity);
         };
 
         return AtmosphereProgram;

--- a/src/shaders/GroundProgram.js
+++ b/src/shaders/GroundProgram.js
@@ -73,6 +73,7 @@ define([
                     'uniform float scaleDepth;\n' + /* The scale depth (i.e. the altitude at which
                      the atmosphere's average density is found) */
                     'uniform float scaleOverScaleDepth;\n' + /* fScale / fScaleDepth */
+                    'uniform float opacity;\n' + /* The opacity of the ground texture */
 
                     'attribute vec4 vertexPoint;\n' +
                     'attribute vec2 vertexTexCoord;\n' +
@@ -138,7 +139,7 @@ define([
                     '    }\n' +
 
                     '    primaryColor = frontColor * (invWavelength * KrESun + KmESun);\n' +
-                    '    secondaryColor = attenuate;\n' + /* Calculate the attenuation factor for the ground */
+                    '    secondaryColor = mix(vec3(1.0, 1.0, 1.0), attenuate, opacity);\n' + /* Calculate the attenuation factor for the ground with opacity */
                     '}\n' +
 
                     'void main()\n ' +


### PR DESCRIPTION
### Description of the Change
Added the ability to control the opacity of the night-image used in the AtmosphereLayer.

### Why Should This Be In Core?
An opaque low-resolution night-image can hide the details of underlying higher-resolution imagery.

### Benefits
A translucent night-image allows the details of the underlying imagery to become visible.
