### PR TITLE
Improve resolution of Bing imagery

### DIFF
--- a/src/layer/BingTiledImageLayer.js
+++ b/src/layer/BingTiledImageLayer.js
@@ -59,6 +59,10 @@ define([
             this.pickEnabled = true;
 
             this.detectBlankImages = true;
+            
+            // Set the detail control so the resolution is a close match 
+            // to the resolution on the Bing maps website
+            this.detailControl = 1.25;
         };
 
         // Internal use only. Intentionally not documented.


### PR DESCRIPTION
### Description of the Change
Improved the resolution of the Bing imagery layers:

- Bing Aerial
- Bing Aerial with labels
- Bing Roads 

### Why Should This Be In Core?
The resolution displayed on the globe was less than the resolution provided by Bing.

### Benefits
Increased clarity and detail.

### Potential Drawbacks
Labels may be smaller.