### PR TITLE
Remove half-meter upper bound for tile imagery.

### DIFF
--- a/src/util/Tile.js
+++ b/src/util/Tile.js
@@ -326,7 +326,7 @@ define([
                 distance = this.distanceTo(dc.eyePoint),
                 pixelSize = dc.pixelSizeAtDistance(distance);
 
-            return cellSize > Math.max(detailFactor * pixelSize, 0.5);
+            return cellSize > detailFactor * pixelSize;
         };
 
         /**


### PR DESCRIPTION
This pull-request was originally submitted by @kyonifer to NASAWorldWind/WebWorldWind.

### Description of the Change
Per @kyonifer: On the current develop branch, worldwind limits the resolution of image tiles to 0.5m. When visualizing scenes which are low to the ground (such as geolocated vehicles) this can be insufficient resolution to view a scene in full detail.

This PR removes the artificial limit in mustSubdivide, which in turn allows the layer providers to regain control over the maximum resolution they can support. For example, the Bing tiled image layer supports 23 levels of imagery, some of which are unavailable before this MR because mustSubdivide begins returning false before the higher levels are reached. A side-by-side comparison of using the BingAerialLayer before and after this MR is below:

### Why Should This Be In Core?
Per @kyonifer: The current resolution limit is hard-coded in core, thus must be modified there.

### Benefits
Per @kyonifer: The ability to render arbitrarily small scenes, which would commonly include situations such as geolocated vehicles and 3D renders of individual buildings.

### Potential Drawbacks
Per @kyonifer: The current limit may be there to reduce accidental bandwidth usage. In this case I'd request that a configurable option be included to set the minimum tile resolution to something other than 0.5.



