### PR TITLE
Improve layer resolution 

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,21 @@ and features from the WebWorldWind's develop branch plus several enhancements fr
 - Removed dependency vulnerabilities
 
 ### Additional Resources
+#### Tutorials
+- [How to Build a WorldWindJS Web App](https://emxsys.github.io/worldwindjs/) on the project website
 
-- View the tutorial [How to Build a WorldWindJS Web App](https://emxsys.github.io/worldwindjs/) on the project website
-- Download __[worldwindjs](https://www.npmjs.com/package/worldwindjs)__ from npm.
-- Add a 3D globe or map to a React app using the __[worldwind-react-globe](https://www.npmjs.com/package/worldwind-react-globe)__ Globe component from npm.
-- Add a layer manager and other controls to a React-based globe using the __[worldwind-react-globe-bs4](https://www.npmjs.com/package/worldwind-react-globe-bs4)__ Bootstrap UI controls.
-- View the React-based __worldwind-react-app__ [live demo](https://emxsys.github.io/worldwind-react-app/) and [GitHub project](https://github.com/emxsys/worldwind-react-app) to see the __worldwind-react-globe__ and __worldwind-react-globe-bs4__ components in action.
+#### Demos
+- [__worldwind-web-app__ demo](https://emxsys.github.io/worldwind-web-app/): A geo-browser built with Bootstrap and KnockoutJS.
+- [__worldwind-react-app__ demo](https://emxsys.github.io/worldwind-react-app/): A geo-browser built with React using the [worldwind-react-globe](https://github.com/emxsys/worldwind-react-globe) and [worldwind-react-globe-bs4](https://github.com/emxsys/worldwind-react-globe-bs4) components.
+
+#### Related projects
+- __[worldwind-react-globe](https://github.com/emxsys/worldwind-react-globe)__: A React-based Globe component that encapulates WorldWindJS.
+- __[worldwind-react-globe-bs4](https://github.com/emxsys/worldwind-react-globe-bs4)__: Bootstrap UI components for the Globe component including a layer manager, tools palette, placename search, and settings.
+
+#### NPM Downloads
+- [__worldwindjs__ package](https://www.npmjs.com/package/worldwindjs): This library as an npm package.
+- [__worldwind-react-globe__ package](https://www.npmjs.com/package/worldwind-react-globe): Globe component encapulating WorldWindJS.
+- [__worldwind-react-globe-bs4__ package](https://www.npmjs.com/package/worldwind-react-globe-bs4): Bootstrap UI for the Globe component.
 
 ---
 

--- a/src/util/Tile.js
+++ b/src/util/Tile.js
@@ -16,6 +16,7 @@
  * 
  * NOTICE: This file was modified from the original NASAWorldWind/WebWorldWind distribution.
  * NOTICE: This file contains changes made by Kyle Kauffman (Github: @kyonifer)
+ * NOTICE: This file contains changes made by Bruce Schubert (bruce@emxsys.com)
  * 
  */
 /**
@@ -141,6 +142,15 @@ define([
              * @default 1
              */
             this.opacity = 1;
+            
+            /**
+             * Set minCellSize to a value greater than zero to limit the tile subdivision to a particular
+             * pixel size (typically measured in meters per pixel).
+             * @type Number
+             * @default 0.1
+             * @see mustSubdivide
+             */
+            this.minCellSize = 0.1;
 
             // Internal use only. Intentionally not documented.
             this.samplePoints = null;
@@ -330,7 +340,7 @@ define([
                 distance = this.distanceTo(dc.eyePoint),
                 pixelSize = dc.pixelSizeAtDistance(distance);
 
-            return cellSize > detailFactor * pixelSize;
+          return cellSize > Math.max(detailFactor * pixelSize, this.minCellSize);
         };
 
         /**

--- a/src/util/Tile.js
+++ b/src/util/Tile.js
@@ -13,6 +13,10 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * 
+ * NOTICE: This file was modified from the original NASAWorldWind/WebWorldWind distribution.
+ * NOTICE: This file contains changes made by Kyle Kauffman (Github: @kyonifer)
+ * 
  */
 /**
  * @exports Tile


### PR DESCRIPTION
This pull-request was originally submitted by @kyonifer to NASAWorldWind/WebWorldWind. 

## Description of the Change
Per @kyonifer: On the current develop branch, WorldWind limits the resolution of image tiles to >= 0.5m. When visualizing scenes which are low to the ground (such as geolocated vehicles) this can be insufficient resolution to view a scene in full detail.

This PR adds a configurable limit for `Tile.mustSubdivide()`. The new `Tile.minCellSize` property allows the layer providers to regain control over the maximum resolution they can support. For example, the Bing tiled image layer supports 23 levels of imagery, some of which are unavailable before this PR because `mustSubdivide` begins returning false before the higher levels are reached. The default value for `minCellSize` is 0.1m

## Why Should This Be In Core?
The current resolution limit is hard-coded in core, thus must be modified there.

## Benefits
The ability to render arbitrarily small scenes, which would commonly include situations such as geolocated vehicles and 3D renders of individual buildings.
