### PR TITLE
Add NASAWorldWind methods to Placemark

### DIFF
--- a/src/shapes/Placemark.js
+++ b/src/shapes/Placemark.js
@@ -794,5 +794,15 @@ define([
                 && (!dc.pickingMode || this.enableLeaderLinePicking);
         };
 
+        // Internal use only. Intentionally not documented.
+        Placemark.prototype.getReferencePosition = function () {
+            return this.position;
+        };
+
+        // Internal use only. Intentionally not documented.
+        Placemark.prototype.moveTo = function (globe, position) {
+            this.position = position;
+        };
+
         return Placemark;
     });


### PR DESCRIPTION
Add `moveTo` and `getReferencePosition` methods to `Placemark` - used in Shape Editor