### PR TITLE
Improved accurancy of radius used in EPSG 3857 to 4326 conversion.

### DIFF
--- a/src/util/WWMath.js
+++ b/src/util/WWMath.js
@@ -771,7 +771,7 @@ define([
             },
 
             epsg3857ToEpsg4326: function (easting, northing) {
-                var r = 6.3781e6,
+                var r = 6.378137e6,
                     latRadians = (Math.PI / 2) - 2 * Math.atan(Math.exp(-northing / r)),
                     lonRadians = easting / r;
 


### PR DESCRIPTION
- Changed radius from 6,378,100 to 6,378,137
- Re: https://github.com/NASAWorldWind/WebWorldWind/issues/793
